### PR TITLE
Allow seconds in settime

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -247,7 +247,7 @@ Allows us to update the datalogger datetime and returns the new value.
     positional arguments:
     url                Specifiy URL for connection link. E.g. tcp:iphost:port or
                        serial:/dev/ttyUSB0:19200:8N1
-    datetime           The chosen datetime value. (like : "2012-07-16 21:58")
+    datetime           The chosen datetime value. (like : "2012-07-16 21:58:23")
 
     optional arguments:
     -h, --help         Show this help message and exit
@@ -261,9 +261,9 @@ Allows us to update the datalogger datetime and returns the new value.
 
 .. code-block:: console
 
-    $ pycr1000 settime serial:/dev/ttyUSB0:19200:8N1 "2012-07-16 23:00"
-    Old Time : 2012-07-16 22:00
-    Current Time : 2012-07-16 23:00
+    $ pycr1000 settime serial:/dev/ttyUSB0:19200:8N1 "2012-07-16 23:00:00"
+    Old Time : 2012-07-16 22:00:12
+    Current Time : 2012-07-16 23:00:00
 
 
 Getprogstat

--- a/pycampbellcr1000/__main__.py
+++ b/pycampbellcr1000/__main__.py
@@ -33,9 +33,9 @@ def gettime_cmd(args, device):
 def settime_cmd(args, device):
     '''Settime command.'''
     old_time = device.gettime()
-    device.settime(datetime.strptime(args.datetime, "%Y-%m-%d %H:%M"))
-    print("Old Time : %s" % old_time.strftime("%Y-%m-%d %H:%M"))
-    print("Current Time : %s" % device.gettime().strftime("%Y-%m-%d %H:%M"))
+    device.settime(datetime.strptime(args.datetime, "%Y-%m-%d %H:%M:%S"))
+    print("Old Time : %s" % old_time.strftime("%Y-%m-%d %H:%M:%S"))
+    print("Current Time : %s" % device.gettime().strftime("%Y-%m-%d %H:%M:%S"))
 
 
 def getprogstat_cmd(args, device):

--- a/pycampbellcr1000/device.py
+++ b/pycampbellcr1000/device.py
@@ -104,7 +104,7 @@ class CR1000(object):
         current_time = self.gettime()
         self.ping_node()
         diff = dtime - current_time
-        diff = diff.days * 86400 + diff.seconds
+        diff = diff.total_seconds()
         # settime (OldTime in response)
         hdr, msg, sdt1 = self.send_wait(self.pakbus.get_clock_cmd((diff, 0)))
         # gettime (NewTime in response)


### PR DESCRIPTION
In this PR, one commit allows setting the logger time to a certain time including seconds. In an other commit, `diff.total_seconds()` replaces the manual calculation `diff.days * 86400 + diff.seconds`.