### PR TITLE
Fix bug with array variables

### DIFF
--- a/pycampbellcr1000/pakbus.py
+++ b/pycampbellcr1000/pakbus.py
@@ -818,7 +818,10 @@ class PakBus(object):
                             values, size = \
                                 self.decode_bin(dimension * [fieldtype],
                                                 raw[offset:])
-                            record['Fields'][fieldname] = values[0]
+                            if dimension>1:
+                                record['Fields'][fieldname] = values
+                            else:
+                                record['Fields'][fieldname] = values[0]
                         offset += size
                     frag['RecFrag'].append(record)
 


### PR DESCRIPTION
PakBus::parse_collectdata() was ignoring the variable dimensionality and
returned only the first element of an array.