### PR TITLE
Connect via pbrouter

### DIFF
--- a/pycampbellcr1000/__main__.py
+++ b/pycampbellcr1000/__main__.py
@@ -169,7 +169,7 @@ def main():
                                      description='Communication tools for '
                                                  'Campbell CR1000-type '
                                                  'Datalogger',
-                                     formatter_class=formatter_class, exit_on_error=False)
+                                     formatter_class=formatter_class)
 
     parser.add_argument('--version', action='version',
                         version='PyCR1000 version %s' % VERSION,

--- a/pycampbellcr1000/__main__.py
+++ b/pycampbellcr1000/__main__.py
@@ -169,7 +169,7 @@ def main():
                                      description='Communication tools for '
                                                  'Campbell CR1000-type '
                                                  'Datalogger',
-                                     formatter_class=formatter_class)
+                                     formatter_class=formatter_class, exit_on_error=False)
 
     parser.add_argument('--version', action='version',
                         version='PyCR1000 version %s' % VERSION,
@@ -239,7 +239,7 @@ def main():
     subparser.add_argument('table', action="store",
                            help="The table name used for data collection")
     subparser.add_argument('output', action='store',
-                           type=argparse.FileType('w', 0),
+                           type=argparse.FileType('w'),
                            help='Filename where output is written')
     subparser.add_argument('--start', help='The beginning datetime record '
                                            '(like : "%s")' % NOW)
@@ -261,7 +261,7 @@ def main():
 
     # Parse argv arguments
     args = parser.parse_args()
-
+    
     if args.debug:
         active_logger()
         device = CR1000.from_url(args.url, args.timeout, args.dest_addr, args.dest,


### PR DESCRIPTION
Fixed so that you can now talk to a logger sitting behind a PakBus router. Tested against a CR1000 behind an NL201 router and an RF401 radio link. You must set --dest to the node address of the logger and --dest_addr to the node address of the pbrouter. 

Still works fine with devices not behind a router - tested on a CR1000 connected directly to ethernet.

May fix #19, but not tested with a CR1000 acting as the router.

Also fixes #14 (getdata error message on argument "output") - the "open" command no longer works unbuffered on text files, so now opens the file using the default buffering.

